### PR TITLE
Small typo fix in download_overlay() message

### DIFF
--- a/R/download_overlay.R
+++ b/R/download_overlay.R
@@ -20,7 +20,7 @@ download_overlay <- function(bounds_sf, zoomlevel, cache_dir, image_provider){
 
     new_bbox <- readRDS(bbox_cache)
   } else {
-    message('Donloading Overlay...')
+    message('Downloading overlay...')
   # dowload tiles and compose raster (SpatRaster)
   nc_esri <- maptiles::get_tiles(x = bounds_sf, provider = image_provider,
                                  crop = TRUE, cachedir = cache_dir,


### PR DESCRIPTION
Just a small typo fix: "Donloading Overlay..." -> "Downloading overlay..."

I saw your [tweet of mountain ranges](https://twitter.com/hughagraham/status/1394253899645734916) and noticed this while checking out the package. Thanks for your work, I'm having fun playing with this already!