### PR TITLE
Dev

### DIFF
--- a/R/define_extent.R
+++ b/R/define_extent.R
@@ -18,11 +18,11 @@ define_extent_sf <- function(req_area){
     sf_geom <- sf::read_sf(req_area)
   }
 
-  if (is.na(sf::st_crs(req_area)[1]$input)) {
+  if (is.na(sf::st_crs(sf_geom)[1]$input)) {
     stop("Requested area has no valid projection. Please set a valid CRS.")
   }
 
-  req_area <- req_area %>%
+  req_area <- sf_geom %>%
     sf::st_transform(3857) %>%
     sf::st_bbox() %>%
     sf::st_as_sfc() #%>%

--- a/R/define_extent.R
+++ b/R/define_extent.R
@@ -10,4 +10,24 @@ define_extent <- function(lat, long, radius, epsg){
   return(extent_sf)
 }
 
+define_extent_sf <- function(req_area){
+  # check if requested area is sf or sf:readable
+  if (class(req_area)[1] == "sf"){
+    sf_geom <- req_area
+  } else {
+    sf_geom <- sf::read_sf(req_area)
+  }
 
+  if (is.na(sf::st_crs(req_area)[1]$input)) {
+    stop("Requested area has no valid projection. Please set a valid CRS.")
+  }
+
+  req_area <- req_area %>%
+    sf::st_transform(3857) %>%
+    sf::st_bbox() %>%
+    sf::st_as_sfc() #%>%
+    # sf::st_sf(crs=3857)
+
+
+  return(req_area)
+}

--- a/R/download_elevation.R
+++ b/R/download_elevation.R
@@ -1,4 +1,4 @@
-download_elevation <- function(bounds_sf, z, cache_dir, outlier_filter,
+download_elevation <- function(bounds_sf, z, dem_src, cache_dir, outlier_filter,
                                fill_holes){
   # get bounds and define cache naming
   bounds <- sf::st_bbox(bounds_sf)
@@ -6,7 +6,7 @@ download_elevation <- function(bounds_sf, z, cache_dir, outlier_filter,
   cachepath <- file.path(cache_dir, paste0('elevation', bounds[1], '_',
                                            bounds[2], '_', bounds[3],
                                         '_', bounds[4], '_' , z, '_',
-                                        outlier_filter, '.rds'))
+                                        outlier_filter, '_', dem_src, '.rds'))
 
   # check cache filename and if it doesn't exist download data then save.
   if (file.exists(cachepath)) {
@@ -17,7 +17,7 @@ download_elevation <- function(bounds_sf, z, cache_dir, outlier_filter,
     # download function - insistently request up to 10 times.
     retrieve_dem <- function(){
       elevatr::get_elev_raster(bounds_sf, z=z, clip='bbox',
-                               neg_to_na = TRUE, verbose = F)
+                               neg_to_na = TRUE, verbose = F, src=dem_src)
     }
     rate <- purrr::rate_backoff(max_times = 10)
     repeat_dem_download <- purrr::insistently(retrieve_dem, rate, quiet=T)

--- a/man/plot_3d_vista.Rd
+++ b/man/plot_3d_vista.Rd
@@ -8,8 +8,10 @@ plot_3d_vista(
   lat,
   long,
   radius = 7000,
+  req_area = NULL,
   elevation_detail = 13,
   overlay_detail = 13,
+  elevation_src = "aws",
   img_provider = "Esri.WorldImagery",
   zscale = 2,
   cache_dir = tempdir(),
@@ -29,12 +31,21 @@ plot_3d_vista(
 \item{radius}{numeric vector - the search radius which will define the
 bounding box area.}
 
+\item{req_area}{Default is `NULL`. If desired, you can porvide an {sf} obect
+or an sf readable file path. If used, lat/long/radius are ignored. Must have
+a valid CRS.}
+
 \item{elevation_detail}{Default is `13`. Integer between (0:15) passed to
 `elevatr::get_elevation_raster`. determines the resolution of the returned
 DEM. see details...}
 
-\item{overlay_detail}{Default is `14`. Integer between (0:20) passed to
-`maptiles::get_tiles`
+\item{overlay_detail}{Default is `13`. Integer between (0:20) passed to
+`maptiles::get_tiles`}
+
+\item{elevation_src}{Default is `aws`. passed to `elevatr::get_elev_raster`.
+A character indicating which API to use. Currently supports "aws" and "gl3",
+"gl1", or "alos" from the OpenTopography API global datasets. "aws" is the
+default.
 This determines the detail of the imagery. see details...}
 
 \item{img_provider}{Default is 'Esri.WorldImagery'. The name of the tile


### PR DESCRIPTION
Added the `req_area` argument to allow user to define requested area with sf object or sf readable filepath. 
All elevation sources from {elevatr} are now supported with the `elevation_src` argument. 