### PR TITLE
Add `outlier_filter` to the example

### DIFF
--- a/R/plot_3d_vista.R
+++ b/R/plot_3d_vista.R
@@ -89,7 +89,7 @@
 #' .lat <- 57.21956608144513
 #' .long <- -6.092690805001252
 #'
-#' cuillins <- plot_3d_vista(lat = .lat, long = .long)
+#' cuillins <- plot_3d_vista(lat = .lat, long = .long, outlier_filter=0.001)
 #' rayshader::render_snapshot(clear=TRUE)
 
 plot_3d_vista <- function(lat, long, radius=7000, req_area=NULL, dem=NULL,


### PR DESCRIPTION
to avoid the plot having a really tall base because of outlier data